### PR TITLE
validate should use %s

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   template:
     src: aide.conf.j2
     dest: /etc/aide.conf
-    validate: aide -D -c /etc/aide.conf
+    validate: aide -D -c %s
 
 #Setup crontab
 - name: Ensure aide check is setup in crontab - No Email Report


### PR DESCRIPTION
Ansible 2.4 fails `"validate must contain %s: aide -D -c /etc/aide.conf"` currently