### PR TITLE
Support --check mode (Execute `which aide` even when check mode)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
   shell: "which aide"
   register: "aide_path"
   changed_when: False
+  check_mode: False
 
 - name: "Check for existing aide database"
   stat:


### PR DESCRIPTION
Fix problem => When `ansible-playbook .. --check`, following tasks always fails.

```
TASK [ahuffman.aide : Configure aide] **************************************************************
fatal: [prod-rails-teamup]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'stdout'\n\nThe error appears to have been in '/path/to/ahuffman.aide/tasks/main.yml': line 36, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Configure aide\"\n  ^ here\n"}
```