### PR TITLE
Added option to call aide with configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ An Ansible role to install, configure, and schedule AIDE.
 |aide_config_version|The value of config_version is printed in the report and also printed to the database.  This  is  for  informational  purposes only. It has no other functionality.| No | "1" | string |
 |aide_cron_schedule_check|Whether or not to setup a cron job for running an aide check|Yes|True|boolean|
 |aide_cron_email_notify_recipients|List of email recipients to get an email notification after a cronjob.  Leave list empty if you do not want this functionality.|Yes|[]|list|
+|aide_call_without_parms | Define if the aide command is call without the configuration file (if False `aide` is call as `aide -c aide_conf_path`)|No|True|boolean|
 |aide_cronjob_name | Comment to insert prior to the cronjob in the crontab|Yes|"aide scheduled database checkup"|string|
 |aide_cron_sched_min|Minute to schedule the start of the cronjob at|No|"0"|string|
 |aide_cron_sched_hr|Hour to schedule the start of the cronjob at|No|"1"|string|
@@ -40,15 +41,15 @@ An Ansible role to install, configure, and schedule AIDE.
 
 ## Defining and Undefining aide.conf Variables
 ```yaml
-aide_macros:   
-  define:   
+aide_macros:
+  define:
      - name: "Give it a name"
        variable: "Name_of_Variable"
        value: "Value of the variable"
      - name: "DBDIR var"
        variable: "DBDIR"
        value: "/var/lib/aide"
-  undefine:   
+  undefine:
      - name: "Some var to undefine"
        variable: "Name_of_Variable"  #This would effectively undefine the variable we defined above
      - name: "Undefining DBDIR var"
@@ -56,33 +57,33 @@ aide_macros:
 ```
 
 ## Defining Rules/Groups, Selection paths, and Ignore/Negative Selection Paths
-A YAML spec was built to handle all of these items in a relatively organized way.  
+A YAML spec was built to handle all of these items in a relatively organized way.
 
 ### Attributes available to a rule
 ```yaml
-aide_rules:   
-  - name: "My first rule"                                                #Required   
-    rule: "FIPSR"                                                        #Required   
-    comment: "Comment to put above this rule declaration"                #Optional   
-    attributes: []  #List made up of default rules or defined rules      #Required except on special negative rule   
-    paths:                                                               #Optional   
-       - "/my/include/path/1"  #Cannot start with '!' see Ignore/Negative Selection Paths   
+aide_rules:
+  - name: "My first rule"                                                #Required
+    rule: "FIPSR"                                                        #Required
+    comment: "Comment to put above this rule declaration"                #Optional
+    attributes: []  #List made up of default rules or defined rules      #Required except on special negative rule
+    paths:                                                               #Optional
+       - "/my/include/path/1"  #Cannot start with '!' see Ignore/Negative Selection Paths
        - "/my/include/path/2"
 ```
 
 ### A Special Rule to handle Ignore/Negative Selection Paths is available
 
-Add a rule to your `aide_rules`: definition with `rule`: negative   
-Here's an example, and you can also find an example in this Role's defaults/main.yml:   
+Add a rule to your `aide_rules`: definition with `rule`: negative
+Here's an example, and you can also find an example in this Role's defaults/main.yml:
 ```yaml
-aide_rules:   
-  - name: "My negative/ignore selections"                                #Required   
-    rule: "negative"                                                     #Required   
-    paths:                                                             #Required   
+aide_rules:
+  - name: "My negative/ignore selections"                                #Required
+    rule: "negative"                                                     #Required
+    paths:                                                             #Required
        - "/my/ignore/path/1"
        - "/my/ignore/path/2"
 ```
-Do not include an '!' in front of the paths, the template logic will automatically do this for you.  
+Do not include an '!' in front of the paths, the template logic will automatically do this for you.
 
 ### Scheduled Cron Aide Checks
 The default is to setup an 'aide --check' in crontab.  Should you wish to change this after already allowing this role to create the cron job, simply switch the variable `aide_cron_schedule_check` to False.  This will remove the cron job from your system's crontab on the next playbook run.  One caveat to be aware of is that the `aide_cronjob_name` variable must match what's currently in the crontab to be removed properly.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,16 @@
 ---
-aide_pkg: "aide"                                         #override with a specific version if required
+aide_pkg: "aide"
 aide_dbdir: "/var/lib/aide"
 aide_logdir: "/var/log/aide"
 aide_conf_path: "/etc/aide.conf"
-aide_update_db: False
+aide_update_db: false
 # Whether or not to update the aide database this run if it exists
-aide_macros: False
+aide_macros: false
 # Define a variable example
 define:
-#    - name: DBDIR variable
-#      variable: DBDIR
-#      value: "{{ aide_dbdir }}"
+# - name: DBDIR variable
+#   variable: DBDIR
+#     value: "{{ aide_dbdir }}"
   - name: "LOGDIR variable"
     variable: "LOGDIR"
     value: "{{ aide_logdir }}"
@@ -18,33 +18,39 @@ define:
 #  undefine:
 #    - name: Undefine DBDIR
 #      variable: 'DBDIR'
-aide_database_filename: "aide.db.gz"                    #only the filename, no path
-aide_database_out_filename: "aide.db.new.gz"            #only the filename, no path
-aide_gzip_dbout: True                                   #yes|no|true|false|True|False
-aide_verbose: 5                                         #level of verbosity 0-255
+aide_database_filename: "aide.db.gz"
+aide_database_out_filename: "aide.db.new.gz"
+aide_gzip_dbout: true
+aide_verbose: 5
 aide_report_url:
   - 'file:@@{LOGDIR}/aide.log'
   - "stdout"
-aide_acl_no_symlink_follow: True                        #yes|true|True|no|false|False
-aide_warn_dead_symlinks: False                          #yes|true|True|no|false|False
-aide_summarize_changes: False                           #yes|true|no|false
-#aide_report_attributes: []                             #list of default rules to report: p,i,n,u,g,s,b,m,a,c,S,acl,selinux,xattrs,md5,sha1,sha256,sha512,rmd160,tiger,haval,gost,crc32,whirlpool
-aide_ignore_list: []                                   #list of default rules to ignore in reports ^
-aide_grouped: False
-aide_config_version: "1"                                  #optional for information only
-aide_cron_schedule_check: True
+aide_acl_no_symlink_follow: true
+aide_warn_dead_symlinks: false
+aide_summarize_changes: false
+# aide_report_attributes: []
+aide_ignore_list: []
+aide_grouped: false
+aide_config_version: "1"
+aide_cron_schedule_check: true
   #Whether or not to add a scheduled aide --check to cron you'd have to manually run your checks if preferred
-aide_cron_email_notify_recipients: []                              #Who to email aide report to after aide --check. Can be comma-separated list
-aide_cronjob_name: "aide scheduled database checkup"                           #will put a comment in crontab for this scheduled job
-aide_cron_sched_min: "0"                                                       #minute
-aide_cron_sched_hr: "1"                                                        #hour
-aide_cron_sched_day: "*"                                                       #day
-aide_cron_sched_mon: "*"                                                       #month
-aide_cron_sched_wkd: "*"                                                       #weekday
+aide_cron_email_notify_recipients: []
+aide_cronjob_name: "aide scheduled database checkup"
+aide_cron_sched_min: "0"
+aide_cron_sched_hr: "1"
+aide_cron_sched_day: "*"
+aide_cron_sched_mon: "*"
+aide_cron_sched_wkd: "*"
+aide_call_without_params: true
+aide_init_cmd: '{{ "aide -i" if aide_call_without_params
+else "aide --init --config=" + aide_conf_path }}'
+aide_check_cmd: '{{ "aide -C" if aide_call_without_params
+else "aide --check --config=" + aide_conf_path }}'
+aide_update_cmd: '{{ "aide -u" if aide_call_without_params
+else "aide --update --config=" + aide_conf_path }}'
 aide_rules:
   - name: "FIPSR Rule"
     rule: "FIPSR"
-#    comment: Example Rule Comment
     attributes: ['p', 'i', 'n', 'u', 'g', 's', 'm', 'c', 'acl', 'selinux', 'xattrs', 'sha256']
   - name: "ALLXTRAHASHES Rule"
     rule: "ALLXTRAHASHES"
@@ -156,7 +162,6 @@ aide_rules:
     attributes: ['p', 'n', 'u', 'g', 's', 'acl', 'selinux', 'xattrs', 'sha256']
     paths:
       - "/etc/resolv.conf"
-#Special rule for ignoring paths. This will add '!' to the beginning of the path for you in the config.
   - name: "Special Negative/Ignore Path rule"
     rule: "negative"
     paths:
@@ -167,3 +172,5 @@ aide_rules:
       - "/var/log/sa"
       - "/var/log/aide.log"
       - "/var/log/and-httpd"
+      - "/var/log/audit/audit.log*"
+      - "/var/log/lastlog"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Initialize aide database"
-  command: "{{ aide_path.stdout }} -i"
+  command: "{{ aide_init_cmd }}"
   when: "not aide_db_check.stat.exists"
 
 - name: "Move new aide database into place"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
     day: "{{ aide_cron_sched_day }}"
     month: "{{ aide_cron_sched_mon }}"
     weekday: "{{ aide_cron_sched_wkd }}"
-    job: "{{ aide_path.stdout }} --check"
+    job: "{{ aide_check_cmd }}"
   when:
     - "aide_cron_email_notify_recipients | length < 1"
     - "aide_cron_schedule_check"
@@ -74,7 +74,7 @@
     day: "{{ aide_cron_sched_day }}"
     month: "{{ aide_cron_sched_mon }}"
     weekday: "{{ aide_cron_sched_wkd }}"
-    job: "{{ aide_path.stdout }} --check | /usr/bin/mail -s 'AIDE Report - $HOSTNAME' {{ aide_cron_email_notify_recipients|join(',') }}"
+    job: "{{ aide_check_cmd }} | /usr/bin/mail -s 'AIDE Report - $HOSTNAME' {{ aide_cron_email_notify_recipients|join(',') }}"
   when:
     - "aide_cron_email_notify_recipients | length > 0"
     - "aide_cron_schedule_check"
@@ -104,7 +104,7 @@
     - "not aide_cron_schedule_check"
 
 - name: "Update aide database"
-  command: "{{ aide_path.stdout }} -u"
+  command: "{{ aide_update_cmd }}"
   register: "aide_update"
   failed_when: "aide_update.rc > 7"
   when:


### PR DESCRIPTION
Solve error `Couldn't open file /var/lib/aide/please-dont-call-aide-without-parameters/aide.db for reading` in Debian. By default will work as previoulsy, but if `aide_call_without_params` is set to `false` will call the command with the configuration file.